### PR TITLE
Removed the issue on whether one should make syntax parameters immutable

### DIFF
--- a/srfi-139.html
+++ b/srfi-139.html
@@ -33,17 +33,6 @@ hygienic implementation of syntactic forms that would otherwise
 introduce implicit identifiers unhygienically.
 </p>
 
-<h1>Issues</h1>
-
-<ul>
-  <li>The syntax parameters described by this SRFI are immutable. In
-    contrast to it, the parameter objects described by SRFI 39 (but
-    not by R7RS) are mutable. Shall syntax parameters be made mutable as
-    well? In contrast to parameter objects, multi-threaded evaluation
-    wouldn't pose a problem, but the precise order of expansion
-    would.</li>
-</ul>
-
 <h1>Rationale</h1>
 
 <p>


### PR DESCRIPTION
There was no demand for mutable syntax parameters and exact semantics
with respect to evaluation in multi-threaded implementations haven't
been proposed either.

With this removal, I consider this SRFI 139 final (as long as there
are no objections being made during the last-call phase).
